### PR TITLE
Add support to provide "Reason" for password retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 coverage.xml
 .vscode/settings.json
 repo.conf
+.idea/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2024-01-15
+### Changes
+- Add support to provide "Reason" when retrieving passwords
+- Update documentation for testing
+
 ## [0.0.28] - 2023-10-12
 ### Changes
 - Changing projet packaging to pyproject.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,17 @@
 # Contributing
 
+<!-- TOC -->
+* [Contributing](#contributing)
+  * [How to contribute](#how-to-contribute)
+  * [Bugs and issues](#bugs-and-issues)
+  * [Code contribution](#code-contribution)
+  * [Test](#test)
+    * [Prepare CyberArk to Run the Testing](#prepare-cyberark-to-run-the-testing)
+      * [Test Accounts and Permissions](#test-accounts-and-permissions)
+      * [Platforms and Apps](#platforms-and-apps)
+    * [Troubleshoot Test Issues](#troubleshoot-test-issues)
+  * [Update documentation](#update-documentation)
+<!-- TOC -->
 ## How to contribute
 
 Any kind of contribution is welcomed. Because this project is quite new the best way to contribute right now is to start to use this module and give feedback about it.
@@ -21,12 +33,50 @@ If you wish to contribute with code the workflow is :
 ## Test
 
 - In order to test you need a working Vault and a PVWA.
-- Then, generate some accounts with mockaroo and the following schemas : https://www.mockaroo.com/b41fedb0
+- Then, generate some accounts with mockaroo and the following schemas : https://www.mockaroo.com/b41fedb0. See "Troubleshoot"
+  section of some cleanup to avoid issues.
 - Create the associated safes : sample-it-dept,sample-iaadmins,sample-coolteam
+- Create safe "BSA-SYS-PTT-R", and grant user "admin_bot" (see below) to the "Safe Management" permissions (for safe
+  rename testing)
 - Import the data (with bulk upload)
 - Create the configuration file for your testing Vault
 - Check the \_\_init__.py file for the location of this file
 - Ensure all tests are passed (or skipped)
+
+### Prepare CyberArk to Run the Testing
+#### Test Accounts and Permissions
+You need an API user, such as **"admin_bot"**, to run the testing. This account is similar to Administrator for
+permissions, but you can't use "Administrator" itself (you will get "PASWS291E You cannot perform this
+task with an Administrator user. Log on with a different user and try again" error)
+* In Private Ark Client:
+  * Add to "Vault Admins" and "PVWAUsers" groups
+  * Give "Add Safes, Audit Users, Add/Update Users, Reset Users' Passwords, Activate Users" authorizations rules.
+  * Add to "admins" group (not sure this is needed)
+  * Add as safe owners for the 3 test safes under user -> "Safe Ownership"
+* In PVWA Browser:
+  * Check "Advanced", "Safe Management", "Account Management" permissions for the 3 test safes.
+
+Create more test accounts In PrivateArk client:
+* Create "admin/Cyberark1" user
+* Create "bastion_std_usr" and "bastion_test_usr" users with any random password
+  * Add "bastion_test_usr" to "Vault Admins" group
+
+In PVWA browser, add "bastion_test_usr" to "sample-it-dept" safe as Members, no special permission needed.
+
+#### Platforms and Apps
+With a freshly installed CyberArk,
+* Activate "Oracle" platform
+* Create and activate "sample_group" as a "group platform".
+
+Finally, create two apps, "TestApp" and "TestApp2".
+
+### Troubleshoot Test Issues
+* `PASWS167E There are some invalid parameters`: The secrets should not include "," or "<".
+* `PASWS159E Parameter [manualManagementReason] cannot be specified with parameter [enableAutomaticManagement]=[True]`: 
+  all the test accounts the "manualManagementReason" need to be empty, if `enableAutomaticManagement == True`.
+* `The number of concurrent dynamic sessions for user admin_bot has reached its limit (300)`: Make sure the tearDown
+  logs off.
+* `PASWS032E Platform [Oracle] is not active`: The Oracle platform is not activated.
 
 
 ## Update documentation

--- a/tests/test_accountgroup.py
+++ b/tests/test_accountgroup.py
@@ -14,7 +14,7 @@ class TestAccountGroup(IsolatedAsyncioTestCase):
         self.test_safe = "sample-it-dept"
 
     async def asyncTearDown(self):
-        await self.vault.close_session()
+        await self.vault.logoff()
 
 
     async def get_random_account_group(self, n=1):

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -12,7 +12,7 @@ class TestApplication(IsolatedAsyncioTestCase):
         self.app_name2 = "TestApp2"
 
     async def asyncTearDown(self):
-        await self.vault.close_session()
+        await self.vault.logoff()
 
 
     async def test_add_application(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,11 @@ class TestEPV(IsolatedAsyncioTestCase):
         await self.vault.login()
 
     async def asyncTearDown(self):
-        await self.vault.close_session()
+        try:
+            await self.vault.logoff()
+        except:
+            # test_logoff 
+            pass
 
     async def test_logoff(self):
         await self.vault.logoff()

--- a/tests/test_cyberark.py
+++ b/tests/test_cyberark.py
@@ -11,7 +11,11 @@ class TestEPV(IsolatedAsyncioTestCase):
         await self.vault.login()
 
     async def asyncTearDown(self):
-        await self.vault.close_session()
+        try:
+            await self.vault.logoff()
+        except:
+            # test_logoff 
+            pass
 
     async def test_logoff(self):
         await self.vault.logoff()

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -13,7 +13,7 @@ class TestApplication(IsolatedAsyncioTestCase):
         await self.vault.login()
 
     async def asyncTearDown(self):
-        await self.vault.close_session()
+        await self.vault.logoff()
 
 
     async def get_random_platform(self, n=1):

--- a/tests/test_safe.py
+++ b/tests/test_safe.py
@@ -14,7 +14,7 @@ class TestSafe(IsolatedAsyncioTestCase):
         self.test_usr = "bastion_std_usr"
 
     async def asyncTearDown(self):
-        await self.vault.close_session()
+        await self.vault.logoff()
 
 
     async def get_random_account(self, n=1):
@@ -65,6 +65,7 @@ class TestSafe(IsolatedAsyncioTestCase):
         self.assertTrue(ret)
 
     async def test_add_member(self):
+
         with self.assertRaises(CyberarkAPIException):
             ret = await self.vault.safe.add_member(self.test_safe, self.test_usr, "tutu")
 
@@ -132,7 +133,7 @@ class TestSafe(IsolatedAsyncioTestCase):
         self.assertIn(self.api_user, members)
 
     async def test_is_member_of(self):
-        self.assertTrue(self.vault.safe.is_member_of(self.test_safe, self.api_user))
+        self.assertTrue(await self.vault.safe.is_member_of(self.test_safe, self.api_user))
 
     async def test_get_permissions(self):
         ret = await self.vault.safe.get_permissions(self.test_safe, self.api_user)
@@ -162,7 +163,7 @@ class TestSafe(IsolatedAsyncioTestCase):
         try:
             ret = await self.vault.safe.rename(safe_to_rename, new_name)
         except AiobastionException:
-            pass
+            raise
         self.assertIn(new_name, [s["safeName"] for s in await self.vault.safe.search(new_name)])
         # undo
         ret = await self.vault.safe.rename(new_name, safe_to_rename)

--- a/tests/test_system_health.py
+++ b/tests/test_system_health.py
@@ -11,7 +11,7 @@ class TestSystemHealth(IsolatedAsyncioTestCase):
         await self.vault.login()
 
     async def asyncTearDown(self):
-        await self.vault.close_session()
+        await self.vault.logoff()
 
     async def test_summary(self):
         summary = await self.vault.system_health.summary()

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -15,7 +15,7 @@ class TestUsers(IsolatedAsyncioTestCase):
         self.test_usr = "bastion_std_usr"
 
     async def asyncTearDown(self):
-        await self.vault.close_session()
+        await self.vault.logoff()
 
 
     async def get_random_account(self, n=1):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -17,8 +17,8 @@ class TestUtilities(IsolatedAsyncioTestCase):
         self.test_safe = "sample-it-dept"
 
     async def asyncTearDown(self):
-        await self.vault.close_session()
-        # await self.vault.logoff()
+        # await self.vault.close_session()
+        await self.vault.logoff()
 
     async def get_random_account(self, n=1):
         accounts = await self.vault.account.search_account_by(


### PR DESCRIPTION
It's great to see a fully featured python library. I was doing a PoC by running the tests, and found the missing of "Reason" in password retrievals, so I put in the PR.

The testing has some of the settings, and I updated the doc to help future testing.

** Note, I don't have the AIM module, so nothing changed for the AIM APIs.

Please let me know anything missing on the PR.