### PR TITLE
add keep_cookies to serialized aim fields

### DIFF
--- a/aiobastion/aim.py
+++ b/aiobastion/aim.py
@@ -21,7 +21,8 @@ class EPV_AIM:
     """
     Class managing communication with the Central Credential Provider (AIM) GetPassword Web Service
     """
-    _serialized_fields = ["host", "appid", "cert", "key", "verify", "timeout", "max_concurrent_tasks"]
+    _serialized_fields = ["host", "appid", "cert", "key", "verify", "timeout", "max_concurrent_tasks",
+                         "keep_cookies"]
     _getPassword_request_parm = ["safe", "folder", "object", "username", "address", "database",
                                  "policyid", "reason", "connectiontimeout", "query", "queryformat",
                                  "failrequestonpasswordchange"]


### PR DESCRIPTION
Fix current bug.

Serialize aim config via:
`epv_env = aiobastion.EPV(serialized=config)
`

keep_cookies not found as valid key.
` File "/home/[...]/lib64/python3.11/site-packages/aiobastion/aim.py", line 57, in __init__
    raise AiobastionException(f"Unknown serialized AIM field: {k} = {v!r}")
aiobastion.exceptions.AiobastionException: Unknown serialized AIM field: keep_cookies = False`